### PR TITLE
Add Host and Port in error logs

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -728,7 +728,7 @@ not_connected(_, {retries, CurrRetry, RetriesLeft},
 			{next_state, connected, State,
 				{next_event, internal, {connected, Socket, Protocol}}};
 		{error, Reason} when RetriesLeft =:= 0 ->
-			error_logger:error_msg("Got error ~p. Will stop.", [Reason]),
+			error_logger:error_msg("Got error ~p when connecting to ~p:~p. Will stop.", [Reason, Host, Port]),
 			{stop, {shutdown, Reason}};
 		{error, Reason} ->
 			Timeout0 = maps:get(retry_timeout, Opts, 5000),
@@ -744,7 +744,7 @@ not_connected(_, {retries, CurrRetry, RetriesLeft},
 				_ ->
 					RetriesLeft - 1
 			end,
-			error_logger:error_msg("Got error when retry: ~p, will retry after ~pms. Have retried ~p times, ~p times left.", [Reason, Timeout, CurrRetry, RetriesLeft1]),
+			error_logger:error_msg("Got error ~p when retry connecting to ~p:~p, will retry after ~pms. Have retried ~p times, ~p times left.", [Reason, Host, Port, Timeout, CurrRetry, RetriesLeft1]),
 			{keep_state, State,
 				{state_timeout, Timeout, {retries, CurrRetry + 1, RetriesLeft1}}}
 	end;


### PR DESCRIPTION
It has been difficult debugging connection failures as the error logs displayed don't contain the host being connected to. We have several instances where one service tries to connect to several services through gRPC and it is unclear which ones are causing issues.

I created the PR against this repository as we're using `elixir-grpc` that requires it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elixir-grpc/gun/1)
<!-- Reviewable:end -->
